### PR TITLE
Add userId to JWT content

### DIFF
--- a/src/express/handler.js
+++ b/src/express/handler.js
@@ -15,7 +15,7 @@ export default function OAuthHandler (options = {}) {
 
     debug(`Executing '${options.name}' OAuth Callback`);
     debug(`Calling create on '${authSettings.path}' service with`, entity);
-    app.service(authSettings.path).create(req[options.entity], params).then(result => {
+    app.service(authSettings.path).create(req, params).then(result => {
       res.data = result;
 
       if (options.successRedirect) {

--- a/test/express/handler.test.js
+++ b/test/express/handler.test.js
@@ -45,7 +45,7 @@ describe('express:handler', () => {
       expect(req.app.service).to.have.been.calledOnce;
       expect(req.app.service).to.have.been.calledWith('/authentication');
       expect(service.create).to.have.been.calledOnce;
-      expect(service.create).to.have.been.calledWith(user, params);
+      expect(service.create).to.have.been.calledWith(req, params);
       done();
     });
   });


### PR DESCRIPTION
Solves #4.

When generating the JWT the `userId` needs to be passed in as the payload.  This allows it to be encoded into the token which in turn makes it possible to fetch the user on decode / log in.

The current token content is:

```
{
  "iat": 1481443686,
  "exp": 1481530086,
  "aud": "https://yourdomain.com",
  "iss": "feathers",
  "sub": "anonymous"
}
```

The new content is:
```
{
  "userId": 2,
  "iat": 1481443989,
  "exp": 1481530389,
  "aud": "https://yourdomain.com",
  "iss": "feathers",
  "sub": "anonymous"
}
```

This brings the payload in line with when you login/authenticate via local and when you login via OAuth.