### PR TITLE
Issue #9: Add callbackPath option to support oauth2 endpoint within sub-app or server proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This will pull from your global `auth` object in your config file. It will also 
 {
     idField: '<provider>Id', // The field to look up the entity by when logging in with the provider. Defaults to '<provider>Id' (ie. 'facebookId').
     path: '/auth/<provider>', // The route to register the middleware
+    callbackPath: '/auth/<provider>/callback', // The route to register the callback handler
     callbackURL: 'http(s)://hostame[:port]/auth/<provider>/callback', // The callback url. Will automatically take into account your host and port and whether you are in production based on your app environment to construct the url. (ie. in development http://localhost:3030/auth/facebook/callback)
     entity: 'user', // the entity that you are looking up
     service: 'users', // the service to look up the entity
@@ -98,7 +99,7 @@ An example of customizing the Verifier:
 import oauth2, { Verifier } from 'feathers-authentication-oauth2';
 
 class CustomVerifier extends Verifier {
-  // The verify function has the exact same inputs and 
+  // The verify function has the exact same inputs and
   // return values as a vanilla passport strategy
   verify(req, accessToken, refreshToken, profile, done) {
     // do your custom stuff. You can call internal Verifier methods
@@ -141,7 +142,7 @@ function customizeGithubProfile() {
     // If there is a github field they signed up or
     // signed in with github so let's pull the email. If
     if (hook.data.github) {
-      hook.data.email = hook.data.github.email; 
+      hook.data.email = hook.data.github.email;
     }
 
     // If you want to do something whenever any OAuth

--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,12 @@ export default function init (options = {}) {
     const oauth2Settings = merge({
       idField: `${name}Id`,
       path: `/auth/${name}`,
-      __oauth: true,
-      callbackURL: makeUrl(`/auth/${name}/callback`, app)
+      __oauth: true
     }, pick(authSettings, ...INCLUDE_KEYS), providerSettings, omit(options, ...EXCLUDE_KEYS));
+
+    // Set callback defaults based on provided path
+    oauth2Settings.callbackPath = oauth2Settings.callbackPath || `${oauth2Settings.path}/callback`;
+    oauth2Settings.callbackURL = oauth2Settings.callbackURL || makeUrl(oauth2Settings.callbackPath, app);
 
     if (!oauth2Settings.clientID) {
       throw new Error(`You must provide a 'clientID' in your authentication configuration or pass one explicitly`);
@@ -65,7 +68,7 @@ export default function init (options = {}) {
     debug(`Registering '${name}' Express OAuth middleware`);
     app.get(oauth2Settings.path, auth.express.authenticate(name));
     app.get(
-      url.parse(oauth2Settings.callbackURL).pathname,
+      oauth2Settings.callbackPath,
       auth.express.authenticate(name, oauth2Settings),
       handler,
       auth.express.emitEvents(authSettings),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,10 @@ describe('feathers-authentication-oauth2', () => {
         expect(args.path).to.equal(`/auth/${config.name}`);
       });
 
+      it('sets callbackPath', () => {
+        expect(args.callbackPath).to.equal(`/auth/${config.name}/callback`);
+      });
+
       it('sets callbackURL', () => {
         expect(args.callbackURL).to.equal(`http://localhost:3030/auth/${config.name}/callback`);
       });
@@ -201,6 +205,17 @@ describe('feathers-authentication-oauth2', () => {
       app.setup();
 
       expect(app.get).to.have.been.calledWith(`/auth/${config.name}/callback`);
+
+      app.get.restore();
+    });
+
+    it('registers custom express callback route', () => {
+      sinon.spy(app, 'get');
+      config.callbackPath = `/v1/api/auth/${config.name}/callback`
+      app.configure(oauth2(config));
+      app.setup();
+
+      expect(app.get).to.have.been.calledWith(config.callbackPath);
 
       app.get.restore();
     });


### PR DESCRIPTION
This PR adds an option, `callbackPath` to the oauth setup. This allows the mount point for the callback handler to be decoupled from the callbackURL that is sent to facebook (for example), as is necessary when mounting feathers as a subapp or behind a reverse proxy.

If `callbackPath` is not set, it defaults to the parsed path from the `callbackURL` as before.