### PR TITLE
Follow failureRedirect on oauth2 authentication failure

### DIFF
--- a/src/express/error-handler.js
+++ b/src/express/error-handler.js
@@ -1,0 +1,14 @@
+// The default Express error middleware that gets called by the OAuth callback route.
+
+export default function OAuthErrorHandler (options = {}) {
+  return function (err, req, res, next) {
+    // Set __redirect so that later middleware (e.g., auth.express.failureRedirect) can redirect accordingly
+    if (options.failureRedirect) {
+      res.hook = { data: {} };
+      Object.defineProperty(res.hook.data, '__redirect', { value: { status: 302, url: options.failureRedirect } });
+    }
+
+    next(err);
+  };
+}
+

--- a/src/express/handler.js
+++ b/src/express/handler.js
@@ -30,13 +30,6 @@ export default function OAuthHandler (options = {}) {
       }
 
       next();
-    }).catch(error => {
-      if (options.failureRedirect) {
-        res.hook = { data: {} };
-        Object.defineProperty(res.hook.data, '__redirect', { value: { status: 302, url: options.failureRedirect } });
-      }
-
-      next(error);
-    });
+    }).catch(next);
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { formatter as defaultFormatter } from 'feathers-rest';
 import { omit, pick, makeUrl } from 'feathers-commons';
 import merge from 'lodash.merge';
 import defaultHandler from './express/handler';
+import defaultErrorHandler from './express/error-handler';
 import DefaultVerifier from './verifier';
 
 const debug = Debug('feathers-authentication-oauth2');
@@ -60,6 +61,7 @@ export default function init (options = {}) {
     const Verifier = options.Verifier || DefaultVerifier;
     const formatter = options.formatter || defaultFormatter;
     const handler = options.handler || defaultHandler(oauth2Settings);
+    const errorHandler = defaultErrorHandler(oauth2Settings);
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);
@@ -68,6 +70,7 @@ export default function init (options = {}) {
       url.parse(oauth2Settings.callbackURL).pathname,
       auth.express.authenticate(name, oauth2Settings),
       handler,
+      errorHandler,
       auth.express.emitEvents(authSettings),
       auth.express.setCookie(authSettings),
       auth.express.successRedirect(),

--- a/test/express/error-handler.test.js
+++ b/test/express/error-handler.test.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import errorHandler from '../../src/express/error-handler';
+
+describe('express:error-handler', () => {
+  let req;
+  let res;
+  let error;
+  let options;
+
+  beforeEach(() => {
+    req = {};
+    options = {};
+    res = {
+      hook: {
+        data: {
+          __redirect: {
+            url: '/app'
+          }
+        }
+      }
+    };
+    error = new Error('Authentication Error');
+  });
+
+  describe('when failureRedirect is set', () => {
+    it('sets the redirect object on the response', done => {
+      options.failureRedirect = '/login';
+      errorHandler(options)(error, req, res, () => {
+        expect(res.hook.data.__redirect).to.deep.equal({ status: 302, url: options.failureRedirect });
+        done();
+      });
+    });
+
+    it('calls next with error', done => {
+      delete res.hook;
+      errorHandler(options)(error, req, res, e => {
+        expect(e).to.equal(error);
+        done();
+      });
+    });
+  });
+
+  describe('when failureRedirect is not set', done => {
+    it('calls next with error', done => {
+      delete res.hook;
+      errorHandler(options)(error, req, res, e => {
+        expect(e).to.equal(error);
+        done();
+      });
+    });
+  });
+});

--- a/test/express/handler.test.js
+++ b/test/express/handler.test.js
@@ -89,15 +89,5 @@ describe('express:handler', () => {
         done();
       });
     });
-
-    describe('when failureRedirect is set', () => {
-      it('sets the redirect object on the request', done => {
-        options.failureRedirect = '/login';
-        handler(options)(req, res, () => {
-          expect(res.hook.data.__redirect).to.deep.equal({ status: 302, url: options.failureRedirect });
-          done();
-        });
-      });
-    });
   });
 });


### PR DESCRIPTION
This fixes the issue whereby failureRedirect is not followed when the `app.authenticate` call fails: https://github.com/feathersjs/feathers-authentication/issues/387