### PR TITLE
Simplified redirectOptions (#42)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default function init (options = {}) {
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);
-    app.get(oauth2Settings.path, auth.express.authenticate(name, oauth2Settings[name]));
+    app.get(oauth2Settings.path, auth.express.authenticate(name, oauth2Settings));
     app.get(
       oauth2Settings.callbackPath,
       auth.express.authenticate(name, oauth2Settings),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,13 +114,13 @@ describe('feathers-authentication-oauth2', () => {
 
     it('registers the redirect options on strategy options', () => {
       sinon.spy(authentication.express, 'authenticate');
-
-      const mergedOptions = Object.assign({}, config, globalConfig)
+      
+      const mergedOptions = Object.assign({}, config, globalConfig);
       app.configure(oauth2(mergedOptions));
       app.setup();
-      
-      const strategyOptions = mergedOptions[config.name]
-      expect(authentication.express.authenticate).to.have.been.calledWith(config.name, strategyOptions);
+
+      delete mergedOptions.Strategy;
+      expect(authentication.express.authenticate).to.have.been.calledWith(config.name, sinon.match(mergedOptions));
 
       authentication.express.authenticate.restore();
     });


### PR DESCRIPTION
Fix for redirectOptions. Going from:

```
{
  auth: {
    github: {
        ...
        github: { 
          redirectOptions
        }
   }
}
```

to

```
{
  auth: {
    github: {
        ...
        redirectOptions
   }
}
```


    