### PR TITLE
Update examples to work with latest OAuth payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class CustomVerifier extends Verifier {
 }
 
 app.configure(oauth2({
-  name: 'facebook'
+  name: 'facebook',
   Strategy: FacebookStrategy,
   clientID: '<your client id>',
   clientSecret: '<your client secret>',
@@ -144,9 +144,9 @@ function customizeGithubProfile() {
   return function(hook) {
     console.log('Customizing Github Profile');
     // If there is a github field they signed up or
-    // signed in with github so let's pull the email. If
+    // signed in with github so let's pull the primary account email.
     if (hook.data.github) {
-      hook.data.email = hook.data.github.email;
+      hook.data.email = hook.data.github.profile.emails.find(email => email.primary).value;
     }
 
     // If you want to do something whenever any OAuth

--- a/example/app.js
+++ b/example/app.js
@@ -1,15 +1,15 @@
-var feathers = require('feathers');
-var rest = require('feathers-rest');
-var hooks = require('feathers-hooks');
-var memory = require('feathers-memory');
-var bodyParser = require('body-parser');
-var GithubStrategy = require('passport-github').Strategy;
-var errorHandler = require('feathers-errors/handler');
-var auth = require('feathers-authentication');
-var oauth2 = require('../lib/index');
+const feathers = require('feathers');
+const rest = require('feathers-rest');
+const hooks = require('feathers-hooks');
+const memory = require('feathers-memory');
+const bodyParser = require('body-parser');
+const GithubStrategy = require('passport-github').Strategy;
+const errorHandler = require('feathers-errors/handler');
+const auth = require('feathers-authentication');
+const oauth2 = require('../lib/index');
 
 // Initialize the application
-var app = feathers();
+const app = feathers();
 app.set('port', 3030);
 
 app.configure(rest())
@@ -24,7 +24,7 @@ app.configure(rest())
     Strategy: GithubStrategy,
     clientID: 'your client id',
     clientSecret: 'your client secret',
-    scope: ['user']
+    scope: ['user:email']
   }))
   .use('/users', memory())
   .use(errorHandler());
@@ -35,7 +35,7 @@ function customizeGithubProfile() {
     // If there is a github field they signed up or
     // signed in with github so let's pull the email
     if (hook.data.github) {
-      hook.data.email = hook.data.github.email; 
+      hook.data.email = hook.data.github.profile.emails.find(email => email.primary).value;
     }
 
     return Promise.resolve(hook);


### PR DESCRIPTION
### Summary

This pull request updates both repository examples (`README.md` & `app.js`) to work with [new Github payloads](https://developer.github.com/v3/users/emails) and solves #40. Emails are now an array rather than a single string property so the present examples are failing. Additionally, without explicitly specifying the `user:email` scope, it is possible to retrieve an empty array of emails as the token would be valid only for retrieving public emails. I elected to update the example scope accordingly rather than adding any further complexity to the `customizeGithubProfile` hook by attempting to handle those null cases.

### Other Info

This change should be reflected in the main Feathers documentation referenced in the issue.